### PR TITLE
Use discord.com for invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Funky
 Funky is a Discord bot. Written in JavaScript, with the aid of discord.js.
 
-To see what it can do, invite the bot (https://discordapp.com/oauth2/authorize?client_id=711115573697708042&scope=bot&permissions=2013654134) and run the $help command!
+To see what it can do, invite the bot (https://discord.com/oauth2/authorize?client_id=711115573697708042&scope=bot&permissions=2013654134) and run the $help command!

--- a/src/cmds/information/help.js
+++ b/src/cmds/information/help.js
@@ -40,7 +40,7 @@ module.exports = class HelpCommand extends Command {
                 `These are the available commands for ${message.guild.name}`,
                 `The bot's prefix is: \`${this.client.prefix}\``,
                 `Command parameters: \`<>\` is strict & \`[]\` is optional.`,
-                `Feel free to invite the bot to your other servers using [this link](https://discordapp.com/oauth2/authorize?client_id=711115573697708042&scope=bot&permissions=2013654134).`
+                `Feel free to invite the bot to your other servers using [this link](https://discord.com/oauth2/authorize?client_id=711115573697708042&scope=bot&permissions=2013654134).`
             ]);
 
             let categories;


### PR DESCRIPTION
The invite is currently using discordapp.com when it should use the newer discord.com domain (cdn.discordapp.com hasn't moved over to discord.com domain yet so that shouldn't be changed)